### PR TITLE
Add copy-pipe-and-cancel by analogy with copy-selection-and-cancel

### DIFF
--- a/TODO
+++ b/TODO
@@ -59,7 +59,6 @@
 	* paste w/o trailing whitespace
 	* command to toggle selection not to move it in copy-mode
 	* regex searching
-	* copy-pipe should have -x as well
 	* searching in copy mode should unwrap lines, so if you search for "foobar"
           then it should be found even if it is now "foo\nbar" (if the WRAP flag
           is set on the line)

--- a/tmux.1
+++ b/tmux.1
@@ -1036,6 +1036,7 @@ The following commands are supported in copy mode:
 .It Li "copy-end-of-line" Ta "D" Ta "C-k"
 .It Li "copy-line" Ta "" Ta ""
 .It Li "copy-pipe <command>" Ta "" Ta ""
+.It Li "copy-pipe-and-cancel <command>" Ta "" Ta ""
 .It Li "copy-selection" Ta "" Ta ""
 .It Li "copy-selection-and-cancel" Ta "Enter" Ta "M-w"
 .It Li "cursor-down" Ta "j" Ta "Down"

--- a/window-copy.c
+++ b/window-copy.c
@@ -763,6 +763,11 @@ window_copy_command(struct window_pane *wp, struct client *c, struct session *s,
 		if (strcmp(command, "copy-pipe") == 0) {
 			if (s != NULL) {
 				window_copy_copy_pipe(wp, s, NULL, argument);
+			}
+		}
+		if (strcmp(command, "copy-pipe-and-cancel") == 0) {
+			if (s != NULL) {
+				window_copy_copy_pipe(wp, s, NULL, argument);
 				window_pane_reset_mode(wp);
 			}
 		}


### PR DESCRIPTION
Now copy-pipe doesn't cancel selection